### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The `config.yml` file is populated with defaults on each run (does not overwrite
 
 ### Device discovery
 
-The LoRaWAN to BACnet Bridge listens to messages from the LNS sent via MQTT. Currently, it understands The Things Stack v2 (TTN/TTI) and ChirpStack v3 and v4 payloads.
+The LoRaWAN to BACnet Bridge listens to messages from the LNS sent via MQTT. Currently, it understands The Things Stack v3 (TTN/TTI) and ChirpStack v3 and v4 payloads.
 
 Similar to what different LNS do, the service decodes the raw payload using Javascript decoders in the `decoders` folder (alternatively you can set it to use the pre-decoded object from the LNS). Either way it expects a cayenne-like output to map new magnitudes from different sensors to BACnet objects. 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,8 @@ services:
     # You can either configure the service using a config.yml file inside the configuration folder
     # or use environment variables here (check the README)
     #environment:
-    #  MQTT_SERVER: eu1.cloud.thethings.network
-    #  MQTT_PORT: 1883
-    #  MQTT_USERNAME: my-app@ttn
-    #  MQTT_PASSWORD: NNSXS.UTGKWB.........UPQ
-    #  BACNET_IP: 192.168.1.162
+    #  - MQTT_SERVER=eu1.cloud.thethings.network
+    #  - MQTT_PORT=1883
+    #  - MQTT_USERNAME=my-app@ttn
+    #  - MQTT_PASSWORD=NNSXS.UTGKWB.........UPQ
+    #  - BACNET_IP=192.168.1.162


### PR DESCRIPTION
# README changes:
- I guess it's TTS v3 instead of the old TTS v2.
- I guess you mean docker-compose.yml instead of config.yml.

# docker-compose.yml changes:
- I had to format the environment variable declaration with = instead of : 
- I had to remove the space before 1883 and eu1.cloud.thethings.network in my environment variable otherwise the concatenated eu1.cloud.thethings.network:1883 produced a connexion error ( eu1.cloud.thethings.network: 1883). 
